### PR TITLE
fix: update layout and remove certain console logs

### DIFF
--- a/src/app/components/Features/Game/GameContainer/GameContainer.tsx
+++ b/src/app/components/Features/Game/GameContainer/GameContainer.tsx
@@ -134,15 +134,21 @@ const GameContainer: React.FC<GameContainerProps> = (
             className="flex flex-grow relative justify-center items-center"
         >
             {areaLocationData !== null && (
-                <Container className="z-10 absolute top-[30px] right-[30px]">
-                    <p>
-                        Location {locationsGuessedAmount + 1}/
-                        {Math.min(
-                            gameConfig.locationsPerGame,
-                            areaLocationData.length,
-                        )}
-                    </p>
-                </Container>
+                <div>
+                    <Container className="z-10 absolute top-[30px] right-[30px]">
+                        <p>
+                            Location {locationsGuessedAmount + 1}/
+                            {Math.min(
+                                gameConfig.locationsPerGame,
+                                areaLocationData.length,
+                            )}
+                            {guessed &&
+                                ` - Distance: ${props
+                                    .getLatestLocationResult()
+                                    .distance.toFixed(1)}m`}
+                        </p>
+                    </Container>
+                </div>
             )}
             <GameMap
                 mapData={mapData}
@@ -159,14 +165,6 @@ const GameContainer: React.FC<GameContainerProps> = (
                 }
                 addLocationResult={props.addLocationResult}
             />
-            {guessed && (
-                <Container className="z-10 absolute top-[30px]">
-                    <p>
-                        Distance:{' '}
-                        {props.getLatestLocationResult().distance.toFixed(1)}m
-                    </p>
-                </Container>
-            )}
             {guessed ? (
                 areaLocationData !== null && (
                     <Button

--- a/src/app/components/Features/Game/GameLocationImage/GameLocationImage.tsx
+++ b/src/app/components/Features/Game/GameLocationImage/GameLocationImage.tsx
@@ -20,8 +20,8 @@ const GameLocationImage: React.FC<GameLocationImageProps> = (
                     : 'game-location-image--not-minimized'
             }`}
             style={{
-                maxWidth: '75%',
-                maxHeight: '75%',
+                maxWidth: '70%',
+                maxHeight: '70%',
             }}
         />
     );

--- a/src/app/components/Features/Game/GameMap/GameMap.tsx
+++ b/src/app/components/Features/Game/GameMap/GameMap.tsx
@@ -16,8 +16,6 @@ const GameMap: React.FC<GameMapProps> = (props: GameMapProps) => {
                     return;
                 }
 
-                console.log([e.latlng.lat, e.latlng.lng]);
-
                 props.onGuess();
 
                 // Display the location guessed by the player.


### PR DESCRIPTION
Update the game layout so that it looks better on mobile. It used to be that on mobile, the distance after each guess overlaps with the current location number. Also, remove the console log of the guessed coordinates.