### PR TITLE
feat: add website manifest file

### DIFF
--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,20 @@
+import { MetadataRoute } from 'next';
+
+export default function manifest(): MetadataRoute.Manifest {
+    return {
+        name: 'Do You Know There?',
+        short_name: 'DYKT',
+        description: 'A game to test your knowledge of an area.',
+        start_url: '/',
+        display: 'standalone',
+        background_color: '#005234',
+        theme_color: '#005234',
+        icons: [
+            {
+                src: '/favicon.ico',
+                sizes: 'any',
+                type: 'image/x-icon',
+            },
+        ],
+    };
+}


### PR DESCRIPTION
Add a manifest file to the website. This is needed especially for setting a `short_name`. That way, a name can be used that doesn't get cut off, when adding the website as a bookmark app on mobile.