### PR TITLE
fix: correct location data filename

### DIFF
--- a/src/assets/data/areas/sfu-burnaby/locations.json
+++ b/src/assets/data/areas/sfu-burnaby/locations.json
@@ -103,7 +103,7 @@
     },
     {
         "id": "21c41324f2d576ed82ac10d154acdd29302eb16f",
-        "filename": "21c41324f2d576ed82ac10d154acdd29302eb16f",
+        "filename": "21c41324f2d576ed82ac10d154acdd29302eb16f.jpeg",
         "name": "Rooftop Parking",
         "difficulty": 2,
         "hint": "Around WMC.",


### PR DESCRIPTION
The filename for a location was missing the ".jpeg" file extension.