### PR TITLE
fix: add favicon sizes to manifest file

### DIFF
--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -12,7 +12,7 @@ export default function manifest(): MetadataRoute.Manifest {
         icons: [
             {
                 src: '/favicon.ico',
-                sizes: 'any',
+                sizes: '48x48 32x32 16x16',
                 type: 'image/x-icon',
             },
         ],


### PR DESCRIPTION
Specify the sizes instead of using "any" to avoid an error.