### PR TITLE
feat: add submit button for map location guess

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,10 @@ To set up an area, do the following:
     `click` of
     [src/app/components/Features/Game/GameMap/GameMap.tsx](src/app/components/Features/Game/GameMap/GameMap.tsx).
     Then, start the game and click somewhere on the map, and see the coordiates
-    of the click logged in the console. Anyways, place a list of objects in this
-    file, with properties as shown in the below example:
+    of the click logged in the console. I made a program to import data faster
+    which lets you select on the map where the location should be. I might clean
+    up the data importer and push the code eventually. Anyways, place a list of
+    objects in this file, with properties as shown in the below example:
 
 ```json
 [

--- a/src/app/components/Common/Map/Map.tsx
+++ b/src/app/components/Common/Map/Map.tsx
@@ -1,5 +1,5 @@
-import 'leaflet/dist/leaflet.css';
 import React from 'react';
+import 'leaflet/dist/leaflet.css';
 import { MapContainer, TileLayer } from 'react-leaflet';
 import mapConfig from '@config/map.json';
 import type MapProps from '@typings/map/MapProps';
@@ -9,6 +9,7 @@ const Map: React.FC<MapProps> = (props: MapProps) => {
 
     return props.mapData ? (
         <MapContainer
+            ref={props.mapRef}
             className={props.className}
             center={[props.mapData.center.lat, props.mapData.center.lng]}
             zoom={props.mapData.zoom.initial}
@@ -28,6 +29,7 @@ const Map: React.FC<MapProps> = (props: MapProps) => {
             ]}
             minZoom={props.mapData.zoom.min}
         >
+            {props.children}
             <TileLayer
                 attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'
                 url={mapConfig.url}

--- a/src/app/components/Features/Game/ResultsContainer/ResultsContainer.tsx
+++ b/src/app/components/Features/Game/ResultsContainer/ResultsContainer.tsx
@@ -84,29 +84,41 @@ const ResultsContainer: React.FC<ResultsContainerProps> = (
         );
 
         setPersonalBests(gameResultsPersonalBests);
-    }, []);
+    }, [
+        props.locationResults,
+        totalDistance,
+        closestLocationGuess.distance,
+        furthestLocationGuess.distance,
+    ]);
 
     return (
         <div className="flex flex-grow flex-col items-center p-8 space-y-8 bg-gradient-to-b from-white to-primary-color">
             <Container className="w-full sm:max-w-2xl mx-16">
                 <h1 className="text-3xl font-bold">Results</h1>
+                <p className="italic">Lower distances are better.</p>
                 <p>
-                    Total distance (lower is better): {totalDistance.toFixed(1)}
+                    Total distance: {totalDistance.toFixed(1)}
                     m<br />
                     {personalBests &&
-                        `Personal best: ${personalBests.summary.total.toFixed(1)}m`}
+                        `Personal best: ${personalBests.summary.total.toFixed(
+                            1,
+                        )}m`}
                 </p>
                 <p>
                     Closest guess: {closestLocationGuess.distance.toFixed(1)}m
                     <br />
                     {personalBests &&
-                        `Personal best: ${personalBests.summary.closest.toFixed(1)}m`}
+                        `Personal best: ${personalBests.summary.closest.toFixed(
+                            1,
+                        )}m`}
                 </p>
                 <p>
                     Furthest guess: {furthestLocationGuess.distance.toFixed(1)}m
                     <br />
                     {personalBests &&
-                        `Personal best: ${personalBests.summary.furthest.toFixed(1)}m`}
+                        `Personal best: ${personalBests.summary.furthest.toFixed(
+                            1,
+                        )}m`}
                 </p>
             </Container>
             <Container className="w-full sm:max-w-2xl mx-16">
@@ -122,11 +134,9 @@ const ResultsContainer: React.FC<ResultsContainerProps> = (
                             <p>
                                 {locationResult.distance.toFixed(1)}m<br />
                                 {personalBests &&
-                                    `Personal best: ${
-                                        personalBests.locations[
-                                            locationResult.locationData.id
-                                        ].toFixed(1)
-                                    }m`}
+                                    `Personal best: ${personalBests.locations[
+                                        locationResult.locationData.id
+                                    ].toFixed(1)}m`}
                             </p>
                             <LocationImage
                                 locationData={locationResult.locationData}

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -1,9 +1,16 @@
 'use client';
 import React, { useState } from 'react';
-import GameContainer from '@components/Features/Game/GameContainer';
 import ResultsContainer from '@components/Features/Game/ResultsContainer';
 import useDeveloperMessage from '@hooks/useDeveloperMessage';
 import LocationResult from '@typings/game/LocationResult';
+import dynamic from 'next/dynamic';
+const GameContainer = dynamic(
+    () => import('@components/Features/Game/GameContainer'),
+    {
+        loading: () => null,
+        ssr: false,
+    },
+);
 
 function Game() {
     const [gameOver, setGameOver] = useState(false);

--- a/src/app/types/map/BaseMapProps.ts
+++ b/src/app/types/map/BaseMapProps.ts
@@ -1,8 +1,10 @@
 import MapData from '@typings/data/MapData';
+import L from 'leaflet';
 
 interface BaseMapProps {
     mapData: MapData | null;
     className?: string;
+    mapRef?: React.MutableRefObject<L.Map | null>;
 }
 
 export default BaseMapProps;

--- a/src/app/types/map/GameMapProps.ts
+++ b/src/app/types/map/GameMapProps.ts
@@ -1,16 +1,16 @@
 import BaseMapProps from '@typings/map/BaseMapProps';
 import BaseLocationImageProps from '@typings/locationImage/BaseLocationImageProps';
 import LocationData from '@typings/data/LocationData';
-import LocationResult from '@typings/game/LocationResult';
+import L from 'leaflet';
 
 interface GameMapProps extends BaseMapProps, BaseLocationImageProps {
     minimized: boolean;
     setMinimized: (value: boolean) => void;
-    onGuess: () => void;
+    onPlaceMarker: () => void;
     locationData: LocationData | null;
     guessed: boolean;
-    createOrUpdateRemoveGuessMapInfo: (value: () => void) => void;
-    addLocationResult: (value: LocationResult) => void;
+    guessMarkerCoordinates: L.LatLngExpression | null;
+    setGuessMarkerCoordinates: (value: L.LatLngExpression) => void;
 }
 
 export default GameMapProps;

--- a/src/app/types/map/MapProps.ts
+++ b/src/app/types/map/MapProps.ts
@@ -3,6 +3,7 @@ import BaseMapProps from '@typings/map/BaseMapProps';
 interface MapProps extends BaseMapProps {
     clickHandler?: React.FC;
     zoomControl?: boolean;
+    children?: React.ReactNode;
 }
 
 export default MapProps;

--- a/src/assets/config/theme.json
+++ b/src/assets/config/theme.json
@@ -11,7 +11,10 @@
         },
         "tertiary": {
             "base": "#3b82f6",
-            "dark": "#1d4ed8"
+            "dark": "1d4ed8"
+        },
+        "map": {
+            "line": "#1d4ed8"
         }
     }
 }


### PR DESCRIPTION
Add a submit button for guessing a location. This is so that the guess marker position can be corrected. Also, it prevents accidently submitting on a device such as mobile when trying to zoom in.

As a side effect of this fix, the correct marker popup now uses the LocationImage component instead of a hardcoded <img> content, which is a good change.