### PR TITLE
fix: disable submit button when not minimized

### DIFF
--- a/src/app/components/Features/Game/GameContainer/GameContainer.tsx
+++ b/src/app/components/Features/Game/GameContainer/GameContainer.tsx
@@ -161,13 +161,13 @@ const GameContainer: React.FC<GameContainerProps> = (
                 locationData={locationData}
                 guessMarkerCoordinates={guessMarkerCoordinates}
                 setGuessMarkerCoordinates={setGuessMarkerCoordinates}
-            />
-            {unsubmittedGuess &&
+            >
+                {unsubmittedGuess &&
                 mapData &&
                 guessMarkerCoordinates &&
                 locationData && (
                     <Button
-                        className="z-10 absolute bottom-[50px]"
+                        className="absolute bottom-[50px]"
                         onClick={() => {
                             if (mapRef.current === null) {
                                 return;
@@ -190,6 +190,7 @@ const GameContainer: React.FC<GameContainerProps> = (
                         Submit
                     </Button>
                 )}
+            </GameMap>
             {guessed ? (
                 areaLocationData &&
                 mapData && (


### PR DESCRIPTION
Make the guess submit button disabled when the location image is not minimized. Do this by passing in the submit button as a child to the game map component.