### PR TITLE
build: upgrade @types/node version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
             },
             "devDependencies": {
                 "@types/leaflet": "^1.9.7",
-                "@types/node": "^20",
+                "@types/node": "^22",
                 "@types/react": "^18",
                 "@types/react-dom": "^18",
                 "autoprefixer": "^10",
@@ -44,13 +44,10 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
-            "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
+            "version": "7.28.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+            "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
             "dev": true,
-            "dependencies": {
-                "regenerator-runtime": "^0.14.0"
-            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -259,9 +256,9 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "14.2.3",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.3.tgz",
-            "integrity": "sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA=="
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.31.tgz",
+            "integrity": "sha512-X8VxxYL6VuezrG82h0pUA1V+DuTSJp7Nv15bxq3ivrFqZLjx81rfeHMWOE9T0jm1n3DtHGv8gdn6B0T0kr0D3Q=="
         },
         "node_modules/@next/eslint-plugin-next": {
             "version": "14.0.0",
@@ -273,9 +270,9 @@
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "14.2.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.3.tgz",
-            "integrity": "sha512-3pEYo/RaGqPP0YzwnlmPN2puaF2WMLM3apt5jLW2fFdXD9+pqcoTzRk+iZsf8ta7+quAe4Q6Ms0nR0SFGFdS1A==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.31.tgz",
+            "integrity": "sha512-dTHKfaFO/xMJ3kzhXYgf64VtV6MMwDs2viedDOdP+ezd0zWMOQZkxcwOfdcQeQCpouTr9b+xOqMCUXxgLizl8Q==",
             "cpu": [
                 "arm64"
             ],
@@ -288,9 +285,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "14.2.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.3.tgz",
-            "integrity": "sha512-6adp7waE6P1TYFSXpY366xwsOnEXM+y1kgRpjSRVI2CBDOcbRjsJ67Z6EgKIqWIue52d2q/Mx8g9MszARj8IEA==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.31.tgz",
+            "integrity": "sha512-iSavebQgeMukUAfjfW8Fi2Iz01t95yxRl2w2wCzjD91h5In9la99QIDKcKSYPfqLjCgwz3JpIWxLG6LM/sxL4g==",
             "cpu": [
                 "x64"
             ],
@@ -303,9 +300,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "14.2.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.3.tgz",
-            "integrity": "sha512-cuzCE/1G0ZSnTAHJPUT1rPgQx1w5tzSX7POXSLaS7w2nIUJUD+e25QoXD/hMfxbsT9rslEXugWypJMILBj/QsA==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.31.tgz",
+            "integrity": "sha512-XJb3/LURg1u1SdQoopG6jDL2otxGKChH2UYnUTcby4izjM0il7ylBY5TIA7myhvHj9lG5pn9F2nR2s3i8X9awQ==",
             "cpu": [
                 "arm64"
             ],
@@ -318,9 +315,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "14.2.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.3.tgz",
-            "integrity": "sha512-0D4/oMM2Y9Ta3nGuCcQN8jjJjmDPYpHX9OJzqk42NZGJocU2MqhBq5tWkJrUQOQY9N+In9xOdymzapM09GeiZw==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.31.tgz",
+            "integrity": "sha512-IInDAcchNCu3BzocdqdCv1bKCmUVO/bKJHnBFTeq3svfaWpOPewaLJ2Lu3GL4yV76c/86ZvpBbG/JJ1lVIs5MA==",
             "cpu": [
                 "arm64"
             ],
@@ -333,9 +330,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "14.2.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.3.tgz",
-            "integrity": "sha512-ENPiNnBNDInBLyUU5ii8PMQh+4XLr4pG51tOp6aJ9xqFQ2iRI6IH0Ds2yJkAzNV1CfyagcyzPfROMViS2wOZ9w==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.31.tgz",
+            "integrity": "sha512-YTChJL5/9e4NXPKW+OJzsQa42RiWUNbE+k+ReHvA+lwXk+bvzTsVQboNcezWOuCD+p/J+ntxKOB/81o0MenBhw==",
             "cpu": [
                 "x64"
             ],
@@ -348,9 +345,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "14.2.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.3.tgz",
-            "integrity": "sha512-BTAbq0LnCbF5MtoM7I/9UeUu/8ZBY0i8SFjUMCbPDOLv+un67e2JgyN4pmgfXBwy/I+RHu8q+k+MCkDN6P9ViQ==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.31.tgz",
+            "integrity": "sha512-A0JmD1y4q/9ufOGEAhoa60Sof++X10PEoiWOH0gZ2isufWZeV03NnyRlRmJpRQWGIbRkJUmBo9I3Qz5C10vx4w==",
             "cpu": [
                 "x64"
             ],
@@ -363,9 +360,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "14.2.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.3.tgz",
-            "integrity": "sha512-AEHIw/dhAMLNFJFJIJIyOFDzrzI5bAjI9J26gbO5xhAKHYTZ9Or04BesFPXiAYXDNdrwTP2dQceYA4dL1geu8A==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.31.tgz",
+            "integrity": "sha512-nowJ5GbMeDOMzbTm29YqrdrD6lTM8qn2wnZfGpYMY7SZODYYpaJHH1FJXE1l1zWICHR+WfIMytlTDBHu10jb8A==",
             "cpu": [
                 "arm64"
             ],
@@ -378,9 +375,9 @@
             }
         },
         "node_modules/@next/swc-win32-ia32-msvc": {
-            "version": "14.2.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.3.tgz",
-            "integrity": "sha512-vga40n1q6aYb0CLrM+eEmisfKCR45ixQYXuBXxOOmmoV8sYST9k7E3US32FsY+CkkF7NtzdcebiFT4CHuMSyZw==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.31.tgz",
+            "integrity": "sha512-pk9Bu4K0015anTS1OS9d/SpS0UtRObC+xe93fwnm7Gvqbv/W1ZbzhK4nvc96RURIQOux3P/bBH316xz8wjGSsA==",
             "cpu": [
                 "ia32"
             ],
@@ -393,9 +390,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "14.2.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.3.tgz",
-            "integrity": "sha512-Q1/zm43RWynxrO7lW4ehciQVj+5ePBhOK+/K2P7pLFX3JaJ/IZVC69SHidrmZSOkqz7ECIOhhy7XhAFG4JYyHA==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.31.tgz",
+            "integrity": "sha512-LwFZd4JFnMHGceItR9+jtlMm8lGLU/IPkgjBBgYmdYSfalbHCiDpjMYtgDQ2wtwiAOSJOCyFI4m8PikrsDyA6Q==",
             "cpu": [
                 "x64"
             ],
@@ -528,12 +525,12 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "20.12.11",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.11.tgz",
-            "integrity": "sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==",
+            "version": "22.17.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.1.tgz",
+            "integrity": "sha512-y3tBaz+rjspDTylNjAX37jEC3TETEFGNJL6uQDxwF9/8GLLIjW1rvVHlynyuUKMnMr1Roq8jOv3vkopBjC4/VA==",
             "dev": true,
             "dependencies": {
-                "undici-types": "~5.26.4"
+                "undici-types": "~6.21.0"
             }
         },
         "node_modules/@types/prop-types": {
@@ -648,9 +645,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -1081,49 +1078,75 @@
             "dev": true
         },
         "node_modules/bare-events": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.2.tgz",
-            "integrity": "sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.1.tgz",
+            "integrity": "sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==",
             "dev": true,
             "optional": true
         },
         "node_modules/bare-fs": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.0.tgz",
-            "integrity": "sha512-TNFqa1B4N99pds2a5NYHR15o0ZpdNKbAeKTE/+G6ED/UeOavv8RY3dr/Fu99HW3zU3pXpo2kDNO8Sjsm2esfOw==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.2.0.tgz",
+            "integrity": "sha512-oRfrw7gwwBVAWx9S5zPMo2iiOjxyiZE12DmblmMQREgcogbNO0AFaZ+QBxxkEXiPspcpvO/Qtqn8LabUx4uYXg==",
             "dev": true,
             "optional": true,
             "dependencies": {
-                "bare-events": "^2.0.0",
-                "bare-path": "^2.0.0",
-                "bare-stream": "^1.0.0"
+                "bare-events": "^2.5.4",
+                "bare-path": "^3.0.0",
+                "bare-stream": "^2.6.4"
+            },
+            "engines": {
+                "bare": ">=1.16.0"
+            },
+            "peerDependencies": {
+                "bare-buffer": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-buffer": {
+                    "optional": true
+                }
             }
         },
         "node_modules/bare-os": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.3.0.tgz",
-            "integrity": "sha512-oPb8oMM1xZbhRQBngTgpcQ5gXw6kjOaRsSWsIeNyRxGed2w/ARyP7ScBYpWR1qfX2E5rS3gBw6OWcSQo+s+kUg==",
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
+            "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
             "dev": true,
-            "optional": true
+            "optional": true,
+            "engines": {
+                "bare": ">=1.14.0"
+            }
         },
         "node_modules/bare-path": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.2.tgz",
-            "integrity": "sha512-o7KSt4prEphWUHa3QUwCxUI00R86VdjiuxmJK0iNVDHYPGo+HsDaVCnqCmPbf/MiW1ok8F4p3m8RTHlWk8K2ig==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+            "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
             "dev": true,
             "optional": true,
             "dependencies": {
-                "bare-os": "^2.1.0"
+                "bare-os": "^3.0.1"
             }
         },
         "node_modules/bare-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-1.0.0.tgz",
-            "integrity": "sha512-KhNUoDL40iP4gFaLSsoGE479t0jHijfYdIcxRn/XtezA2BaUD0NRf/JGRpsMq6dMNM+SrCrB0YSSo/5wBY4rOQ==",
+            "version": "2.6.5",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
+            "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
             "dev": true,
             "optional": true,
             "dependencies": {
-                "streamx": "^2.16.1"
+                "streamx": "^2.21.0"
+            },
+            "peerDependencies": {
+                "bare-buffer": "*",
+                "bare-events": "*"
+            },
+            "peerDependenciesMeta": {
+                "bare-buffer": {
+                    "optional": true
+                },
+                "bare-events": {
+                    "optional": true
+                }
             }
         },
         "node_modules/base64-js": {
@@ -1170,9 +1193,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -1180,12 +1203,12 @@
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -1440,9 +1463,9 @@
             "dev": true
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -2386,9 +2409,9 @@
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -3468,12 +3491,12 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
             "dependencies": {
-                "braces": "^3.0.2",
+                "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
             },
             "engines": {
@@ -3546,9 +3569,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
             "funding": [
                 {
                     "type": "github",
@@ -3575,11 +3598,11 @@
             "dev": true
         },
         "node_modules/next": {
-            "version": "14.2.3",
-            "resolved": "https://registry.npmjs.org/next/-/next-14.2.3.tgz",
-            "integrity": "sha512-dowFkFTR8v79NPJO4QsBUtxv0g9BrS/phluVpMAt2ku7H+cbcBJlopXjkWlwxrk/xGqMemr7JkGPGemPrLLX7A==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/next/-/next-14.2.31.tgz",
+            "integrity": "sha512-Wyw1m4t8PhqG+or5a1U/Deb888YApC4rAez9bGhHkTsfwAy4SWKVro0GhEx4sox1856IbLhvhce2hAA6o8vkog==",
             "dependencies": {
-                "@next/env": "14.2.3",
+                "@next/env": "14.2.31",
                 "@swc/helpers": "0.5.5",
                 "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001579",
@@ -3594,15 +3617,15 @@
                 "node": ">=18.17.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "14.2.3",
-                "@next/swc-darwin-x64": "14.2.3",
-                "@next/swc-linux-arm64-gnu": "14.2.3",
-                "@next/swc-linux-arm64-musl": "14.2.3",
-                "@next/swc-linux-x64-gnu": "14.2.3",
-                "@next/swc-linux-x64-musl": "14.2.3",
-                "@next/swc-win32-arm64-msvc": "14.2.3",
-                "@next/swc-win32-ia32-msvc": "14.2.3",
-                "@next/swc-win32-x64-msvc": "14.2.3"
+                "@next/swc-darwin-arm64": "14.2.31",
+                "@next/swc-darwin-x64": "14.2.31",
+                "@next/swc-linux-arm64-gnu": "14.2.31",
+                "@next/swc-linux-arm64-musl": "14.2.31",
+                "@next/swc-linux-x64-gnu": "14.2.31",
+                "@next/swc-linux-x64-musl": "14.2.31",
+                "@next/swc-win32-arm64-msvc": "14.2.31",
+                "@next/swc-win32-ia32-msvc": "14.2.31",
+                "@next/swc-win32-x64-msvc": "14.2.31"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.1.0",
@@ -4172,9 +4195,9 @@
             }
         },
         "node_modules/prebuild-install/node_modules/tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+            "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
             "dev": true,
             "dependencies": {
                 "chownr": "^1.1.1",
@@ -4272,12 +4295,6 @@
                     "url": "https://feross.org/support"
                 }
             ]
-        },
-        "node_modules/queue-tick": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-            "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
-            "dev": true
         },
         "node_modules/rc": {
             "version": "1.2.8",
@@ -4400,12 +4417,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "dev": true
         },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.2",
@@ -4774,13 +4785,13 @@
             }
         },
         "node_modules/streamx": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.16.1.tgz",
-            "integrity": "sha512-m9QYj6WygWyWa3H1YY69amr4nVgy61xfjys7xO7kviL5rfIEc2naf+ewFiOA+aEJD7y0JO3h2GoiUv4TDwEGzQ==",
+            "version": "2.22.1",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
+            "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
             "dev": true,
             "dependencies": {
-                "fast-fifo": "^1.1.0",
-                "queue-tick": "^1.0.1"
+                "fast-fifo": "^1.3.2",
+                "text-decoder": "^1.1.0"
             },
             "optionalDependencies": {
                 "bare-events": "^2.2.0"
@@ -5026,9 +5037,9 @@
             }
         },
         "node_modules/sucrase/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -5142,17 +5153,17 @@
             }
         },
         "node_modules/tar-fs": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
-            "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
+            "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
             "dev": true,
             "dependencies": {
                 "pump": "^3.0.0",
                 "tar-stream": "^3.1.5"
             },
             "optionalDependencies": {
-                "bare-fs": "^2.1.1",
-                "bare-path": "^2.1.0"
+                "bare-fs": "^4.0.1",
+                "bare-path": "^3.0.0"
             }
         },
         "node_modules/tar-stream": {
@@ -5164,6 +5175,15 @@
                 "b4a": "^1.6.4",
                 "fast-fifo": "^1.2.0",
                 "streamx": "^2.15.0"
+            }
+        },
+        "node_modules/text-decoder": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+            "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+            "dev": true,
+            "dependencies": {
+                "b4a": "^1.6.4"
             }
         },
         "node_modules/text-table": {
@@ -5427,9 +5447,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "5.26.5",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
             "dev": true
         },
         "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     },
     "devDependencies": {
         "@types/leaflet": "^1.9.7",
-        "@types/node": "^20",
+        "@types/node": "^22",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "autoprefixer": "^10",


### PR DESCRIPTION
Upgrade `@types/node` to version 22 to match the Node.js version to be used with Vercel.

Also, fix vulnerabilities with `npm audit fix`.